### PR TITLE
Fix/dt integer division

### DIFF
--- a/QPanda3D/QPanda3DWidget.py
+++ b/QPanda3D/QPanda3DWidget.py
@@ -36,6 +36,10 @@ class QPanda3DSynchronizer(QTimer):
         taskMgr.step()
         self.qPanda3DWidget.update()
 
+    def __del__(self):
+        self.stop()
+
+
 
 def get_panda_key_modifiers(evt):
     panda_mods = []

--- a/QPanda3D/QPanda3DWidget.py
+++ b/QPanda3D/QPanda3DWidget.py
@@ -33,8 +33,9 @@ class QPanda3DSynchronizer(QTimer):
         self.timeout.connect(self.tick)
 
     def tick(self):
-        taskMgr.step()
-        self.qPanda3DWidget.update()
+        if self.isActive():
+            taskMgr.step()
+            self.qPanda3DWidget.update()
 
     def __del__(self):
         self.stop()

--- a/QPanda3D/QPanda3DWidget.py
+++ b/QPanda3D/QPanda3DWidget.py
@@ -28,7 +28,7 @@ class QPanda3DSynchronizer(QTimer):
     def __init__(self, qPanda3DWidget, FPS=60):
         QTimer.__init__(self)
         self.qPanda3DWidget = qPanda3DWidget
-        dt = 1000 / FPS
+        dt = 1000 // FPS
         self.setInterval(dt)
         self.timeout.connect(self.tick)
 


### PR DESCRIPTION
1. With PyQt5 5.15.6 QTimer.setInterval expects integer argument.
2. When deleting the widget the timer has to be stopped to prevent tick() call on non existing widget.