### PR TITLE
Fix TypeError in setInterval when using float values

### DIFF
--- a/QPanda3D/QPanda3DWidget.py
+++ b/QPanda3D/QPanda3DWidget.py
@@ -29,7 +29,7 @@ class QPanda3DSynchronizer(QTimer):
         QTimer.__init__(self)
         self.qPanda3DWidget = qPanda3DWidget
         dt = 1000 // FPS
-        self.setInterval(dt)
+        self.setInterval(int(round(dt)))
         self.timeout.connect(self.tick)
 
     def tick(self):


### PR DESCRIPTION
This commit modifies the call to setInterval within QPanda3DSynchronizer to use an integer value. Previously, passing a float value to setInterval caused a TypeError due to it expecting an int argument. The modification uses the round() function to round the float value to the nearest integer before converting it to int. This ensures compatibility with setInterval’s type expectation and prevents the error.

This fixes the reported error where a float value caused a failure when initializing QPanda3DWidget.